### PR TITLE
External events and workflow termination

### DIFF
--- a/src/DaprOrchestrationService.cs
+++ b/src/DaprOrchestrationService.cs
@@ -111,10 +111,10 @@ public class DaprOrchestrationService : OrchestrationServiceBase, IWorkflowExecu
         await proxy.InitAsync(creationMessage, dedupeStatuses);
     }
 
-    public override Task SendTaskOrchestrationMessageAsync(TaskMessage message)
+    public override async Task SendTaskOrchestrationMessageAsync(TaskMessage message)
     {
-        // TODO: Invoke a specific actor API?
-        throw new NotImplementedException();
+        IWorkflowActor proxy = this.GetOrchestrationActorProxy(message.OrchestrationInstance.InstanceId);
+        await proxy.PostToInboxAsync(message);
     }
 
     public override async Task<OrchestrationState> WaitForOrchestrationAsync(
@@ -148,11 +148,6 @@ public class DaprOrchestrationService : OrchestrationServiceBase, IWorkflowExecu
         IWorkflowActor proxy = this.GetOrchestrationActorProxy(instanceId);
         OrchestrationState? state = await proxy.GetCurrentStateAsync();
         return state;
-    }
-
-    public override Task ForceTerminateTaskOrchestrationAsync(string instanceId, string reason)
-    {
-        throw new NotImplementedException();
     }
 
     public override Task PurgeOrchestrationHistoryAsync(

--- a/src/OrchestrationServiceBase.cs
+++ b/src/OrchestrationServiceBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using DurableTask.Core;
+using DurableTask.Core.History;
 
 namespace DurableTask.Dapr;
 
@@ -124,7 +125,16 @@ public abstract class OrchestrationServiceBase : IOrchestrationService, IOrchest
         TimeSpan timeout,
         CancellationToken cancellationToken);
 
-    public abstract Task ForceTerminateTaskOrchestrationAsync(string instanceId, string reason);
+    public virtual Task ForceTerminateTaskOrchestrationAsync(string instanceId, string reason)
+    {
+        var taskMessage = new TaskMessage
+        {
+            OrchestrationInstance = new OrchestrationInstance { InstanceId = instanceId },
+            Event = new ExecutionTerminatedEvent(-1, reason),
+        };
+
+        return this.SendTaskOrchestrationMessageAsync(taskMessage);
+    }
 
     public virtual async Task<IList<OrchestrationState>> GetOrchestrationStateAsync(string instanceId, bool allExecutions)
     {

--- a/src/Workflows/IWorkflowActor.cs
+++ b/src/Workflows/IWorkflowActor.cs
@@ -35,4 +35,11 @@ public interface IWorkflowActor : IActor
     /// </param>
     /// <returns>A task that completes when the activity completion is stored in the workflow state.</returns>
     Task CompleteActivityAsync(ActivityCompletionResponse completionInfo);
+
+    /// <summary>
+    /// Posts a message to the workflow's inbox.
+    /// </summary>
+    /// <param name="message">The message to post.</param>
+    /// <returns>A task that completes when the message is successfully persisted.</returns>
+    Task PostToInboxAsync(TaskMessage message);
 }


### PR DESCRIPTION
Resolves #7 
Resolves #8 

This PR enables both external events and forced workflow termination. The work required to add this was minimal since most of the plumbing has already been done. The following changes were required:

* Add a new `IWorkflowActor` method for posting messages to the workflow inbox
* Add basic implementations to the corresponding `IOrchestrationService` methods.

My testing strategy is as follows:

* I'm hosting the DurableTask.Dapr backend in the Durable Task sidecar process, mimicking the sidecar architecture we're aiming for (this sidecar will communicate with the Dapr sidecar).
* I'm testing this manually using [these Durable Task .NET SDK integration tests](https://github.com/microsoft/durabletask-dotnet/blob/96eff12a93d779cab86f2a8f609be56486326041/test/DurableTask.Sdk.Tests/OrchestrationPatterns.cs#L289-L363), but modified to point to a sidecar process instead of a locally hosted process.

The tests were able to pass without any modifications, giving me confidence that the implementation is (mostly) correct. I could have also run the Durable Task Java SDK tests to validate this scenario, but it shouldn't make any difference since the test logic is roughly the same and the backend implementation is agnostic to the Durable Task client SDK being used.

In a later PR, I'll copy these integration tests directly into this project to ensure they run as part of each PR.